### PR TITLE
Matt - Document Signing, Mediation summary page showing documents, bug fixes, schema changes

### DIFF
--- a/.brakeman.ignore
+++ b/.brakeman.ignore
@@ -3,6 +3,10 @@
     {
       "fingerprint": "517a0b825a8bccfb72b32e0f8f43d42fe6764a280f5de2a6c09c5d54b8e9719e",
       "reason": "Path is sanitized and scoped to public directory. False positive."
+    },
+    {
+      "fingerprint": "7c53b6346e703ef5b1a19fe44a0aec9bd41dbd939f608764e96bc7db4ae884e6",
+      "note": "Path is sanitized and scoped to public directory. False positive."
     }
   ]
 }

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -9,7 +9,25 @@ class DocumentsController < ApplicationController
 
 
 
+  def sign
+    
+    #This is temporary, but does work (obviously does not update the file rn)
+    file = FileDraft.find_by(FileID: params[:id])
+    unless file
+      return render plain: "File not found", status: :not_found 
+    end
 
+    if @user.Role == "Tenant"
+      file.update(TenantSignature: true)
+    elsif @user.Role == "Landlord"
+      file.update(LandlordSignature: true)
+    else
+      render plain: "Not authorized", status: :forbidden
+      return
+    end
+
+    redirect_back fallback_location: messages_path, notice: "Signed successfully!"
+  end
 
 
 

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -49,7 +49,7 @@ class DocumentsController < ApplicationController
     # Build data for the docx template
     data = {
       landlord_name: params[:landlord_name],
-      tenant_name: params[:fname],
+      tenant_name: params[:tenant_name],
       tenant_address: params[:address],
       landlord_company: landlord.CompanyName.to_s,
       negotiation_date: params[:negotiation_date],
@@ -88,12 +88,23 @@ class DocumentsController < ApplicationController
 
     Docsplit.extract_pdf("public/userFiles/#{file_id}.docx", output: "public/userFiles")
 
-    FileDraft.create!(
-      FileName: "#{file_id}",
-      FileTypes: "pdf",
-      FileURLPath: "userFiles/#{file_id}.pdf",
-      CreatorID: @user.UserID
-    )
+    if @user.Role == "Tenant" 
+      FileDraft.create!(
+        FileName: "#{file_id}",
+        FileTypes: "pdf",
+        FileURLPath: "userFiles/#{file_id}.pdf",
+        CreatorID: @user.UserID,
+        TenantSignature: true
+      )
+    elsif @user.Role == "Landlord" 
+      FileDraft.create!(
+        FileName: "#{file_id}",
+        FileTypes: "pdf",
+        FileURLPath: "userFiles/#{file_id}.pdf",
+        CreatorID: @user.UserID,
+        LandlordSignature: true
+      )
+    end 
 
     redirect_to user_role == "Tenant" ? documents_path : landlord_documents_path, notice: "Document generated successfully."
   end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -53,7 +53,8 @@ class DocumentsController < ApplicationController
       tenant_address: params[:address],
       landlord_company: landlord.CompanyName.to_s,
       negotiation_date: params[:negotiation_date],
-      additional_provisions: params[:additional_provisions]
+      additional_provisions: params[:additional_provisions],
+      vacate_date: params[:vacate_date]
     }
 
     if user_role == "Tenant"
@@ -79,11 +80,11 @@ class DocumentsController < ApplicationController
 
     # Save filled document
     File.open(filled_docx_path.to_s, "wb") { |f| f.write(buffer.string) }
-    # unless File.exist?(filled_docx_path)
-    # logger.error "DOCX generation failed"
-    # render plain: "Document generation failed", status: :internal_server_error
-    # return
-    # end
+    unless File.exist?(filled_docx_path)
+      logger.error "DOCX generation failed"
+      render plain: "Document generation failed", status: :internal_server_error
+      return
+    end
 
     Docsplit.extract_pdf("public/userFiles/#{file_id}.docx", output: "public/userFiles")
 

--- a/app/controllers/mediator_cases_controller.rb
+++ b/app/controllers/mediator_cases_controller.rb
@@ -13,18 +13,14 @@ class MediatorCasesController < ApplicationController
       return
     end
 
-    # Get tenant-side conversation
-    tenant_side_group = SideMessageGroup.find_by(
-      UserID: @mediation.TenantID,
-      MediatorID: @mediation.MediatorID
-    )
+    # Get tenant-side conversation, another point of origin for the history bug
+    tenant_side_group = SideMessageGroup.find_by(ConversationID: @mediation.TenantSideConversationID)
+
     tenant_msg_string = tenant_side_group && MessageString.find_by(ConversationID: tenant_side_group.ConversationID)
 
-    # Get landlord-side conversation
-    landlord_side_group = SideMessageGroup.find_by(
-      UserID: @mediation.LandlordID,
-      MediatorID: @mediation.MediatorID
-    )
+    # Get landlord-side conversation, another point of origin for the history bug
+    landlord_side_group = SideMessageGroup.find_by(ConversationID: @mediation.LandlordSideConversationID)
+
     landlord_msg_string = landlord_side_group && MessageString.find_by(ConversationID: landlord_side_group.ConversationID)
 
     @tenant_message_string = tenant_msg_string

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -3,5 +3,4 @@ class FileAttachment < ApplicationRecord
 
     belongs_to :file_draft, foreign_key: :FileID
     belongs_to :message, foreign_key: :MessageID
-
 end

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -1,3 +1,7 @@
 class FileAttachment < ApplicationRecord
     self.table_name = "FileAttachments"
+
+    belongs_to :file_draft, foreign_key: :FileID
+    belongs_to :message, foreign_key: :MessageID
+
 end

--- a/app/models/file_draft.rb
+++ b/app/models/file_draft.rb
@@ -1,3 +1,6 @@
 class FileDraft < ApplicationRecord
     self.table_name = "FileDrafts"
+
+    has_many :file_attachments, foreign_key: :FileID
+
 end

--- a/app/models/file_draft.rb
+++ b/app/models/file_draft.rb
@@ -2,5 +2,4 @@ class FileDraft < ApplicationRecord
     self.table_name = "FileDrafts"
 
     has_many :file_attachments, foreign_key: :FileID
-
 end

--- a/app/views/documents/sign.html.erb
+++ b/app/views/documents/sign.html.erb
@@ -1,0 +1,14 @@
+<h2>Sign Document</h2>
+
+<p>You are signing: <%= @file.FileName %></p>
+
+<%= form_with url: apply_signature_document_path(@file.FileID), method: :post do |form| %>
+  <div>
+    <%= form.label :signature, "Enter your signature:" %><br>
+    <%= form.text_field :signature, required: true %>
+  </div>
+
+  <div>
+    <%= form.submit "Apply Signature" %>
+  </div>
+<% end %>

--- a/app/views/documents/sign.html.erb
+++ b/app/views/documents/sign.html.erb
@@ -5,7 +5,10 @@
 <%= form_with url: apply_signature_document_path(@file.FileID), method: :post do |form| %>
   <div>
     <%= form.label :signature, "Enter your signature:" %><br>
-    <%= form.text_field :signature, required: true %>
+    <%= form.text_field :signature, 
+        required: true, 
+        pattern: "/.+/", 
+        title: "Your signature must start and end with a '/' (example: /John Doe/)" %>
   </div>
 
   <div>

--- a/app/views/messages/_mediator_chatbox.html.erb
+++ b/app/views/messages/_mediator_chatbox.html.erb
@@ -25,9 +25,9 @@
                     <%= link_to "View", document_path(file.FileID), class: "btn btn-link" %> |
                     <%= link_to "Download", download_file_path(file.FileID), class: "btn btn-link" %></p>
                     <% if @user.Role == 'Tenant' && file.TenantSignature == false %>
-                      <%= button_to "Sign as Tenant", sign_file_path(file.FileID), method: :post %>
+                      <%= button_to "Sign as Tenant", sign_document_path(file.FileID), method: :get %>
                     <% elsif @user.Role == 'Landlord' && file.LandlordSignature == false %>
-                      <%= button_to "Sign as Landlord", sign_file_path(file.FileID), method: :post %>
+                      <%= button_to "Sign as Landlord", sign_document_path(file.FileID), method: :get %>
                     <% end %>
               <small class="message-timestamp"><%= message.MessageDate.strftime("%B %d, %Y %I:%M %p") %></small>
             </div>

--- a/app/views/messages/_mediator_chatbox.html.erb
+++ b/app/views/messages/_mediator_chatbox.html.erb
@@ -24,6 +24,11 @@
                     File attached: <%= file.FileName %> 
                     <%= link_to "View", document_path(file.FileID), class: "btn btn-link" %> |
                     <%= link_to "Download", download_file_path(file.FileID), class: "btn btn-link" %></p>
+                    <% if @user.Role == 'Tenant' && file.TenantSignature == false %>
+                      <%= button_to "Sign as Tenant", sign_file_path(file.FileID), method: :post %>
+                    <% elsif @user.Role == 'Landlord' && file.LandlordSignature == false %>
+                      <%= button_to "Sign as Landlord", sign_file_path(file.FileID), method: :post %>
+                    <% end %>
               <small class="message-timestamp"><%= message.MessageDate.strftime("%B %d, %Y %I:%M %p") %></small>
             </div>
           </div>

--- a/app/views/messages/_negotiation_chatbox.html.erb
+++ b/app/views/messages/_negotiation_chatbox.html.erb
@@ -25,9 +25,9 @@
                     <%= link_to "View", document_path(file.FileID), class: "btn btn-link" %> |
                     <%= link_to "Download", download_file_path(file.FileID), class: "btn btn-link" %></p>
                     <% if @user.Role == 'Tenant' && file.TenantSignature == false %>
-                      <%= button_to "Sign as Tenant", sign_file_path(file.FileID), method: :post %>
+                      <%= button_to "Sign as Tenant", sign_document_path(file.FileID), method: :get %>
                     <% elsif @user.Role == 'Landlord' && file.LandlordSignature == false %>
-                      <%= button_to "Sign as Landlord", sign_file_path(file.FileID), method: :post %>
+                      <%= button_to "Sign as Landlord", sign_document_path(file.FileID), method: :get %>
                     <% end %>
               <small class="message-timestamp"><%= message.MessageDate.strftime("%B %d, %Y %I:%M %p") %></small>
             </div>

--- a/app/views/messages/_negotiation_chatbox.html.erb
+++ b/app/views/messages/_negotiation_chatbox.html.erb
@@ -24,6 +24,11 @@
                     File attached: <%= file.FileName %> 
                     <%= link_to "View", document_path(file.FileID), class: "btn btn-link" %> |
                     <%= link_to "Download", download_file_path(file.FileID), class: "btn btn-link" %></p>
+                    <% if @user.Role == 'Tenant' && file.TenantSignature == false %>
+                      <%= button_to "Sign as Tenant", sign_file_path(file.FileID), method: :post %>
+                    <% elsif @user.Role == 'Landlord' && file.LandlordSignature == false %>
+                      <%= button_to "Sign as Landlord", sign_file_path(file.FileID), method: :post %>
+                    <% end %>
               <small class="message-timestamp"><%= message.MessageDate.strftime("%B %d, %Y %I:%M %p") %></small>
             </div>
           </div>

--- a/app/views/messages/summary.html.erb
+++ b/app/views/messages/summary.html.erb
@@ -52,19 +52,24 @@
     </div>
 
     <div class="summary-section">
-      <h2><i class="fa-solid fa-paperclip"></i> Attached Documents</h2>
-      <% if @fully_signed_files.any? %>
-        <ul class="document-list">
-          <% @fully_signed_files.each do |file| %>
-            <li>
-              <i class="fa-solid fa-file-lines"></i>
-              <%= link_to file.FileName, "/#{file.FileURLPath}", target: "_blank" %>
-            </li>
-          <% end %>
-        </ul>
-      <% else %>
-        <p>No documents were signed by both parties during this mediation.</p>
+      <h2><i class="fa-solid fa-paperclip"></i> Signed Attached Documents</h2>
+
+      <% @signed_files.each do |file| %>
+        <% conversation_label = case file.ConversationID %>
+          <% when @mediation.ConversationID %>
+            <span class="tag primary">Main Negotiation</span>
+          <% when @mediation.TenantSideConversationID %>
+            <span class="tag tenant-side">Tenant Side Mediation</span>
+          <% when @mediation.LandlordSideConversationID %>
+            <span class="tag landlord-side">Landlord Side Mediation</span>
+          <% else %>
+            <span class="tag unknown">Unknown Group</span>
+        <% end %>
+        <li>
+          <i class="fa-solid fa-file-lines"></i>
+          <%= link_to file.FileName, "/#{file.FileURLPath}", target: "_blank" %>
+          <%= conversation_label.html_safe %>
+        </li>
       <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/messages/summary.html.erb
+++ b/app/views/messages/summary.html.erb
@@ -53,9 +53,17 @@
 
     <div class="summary-section">
       <h2><i class="fa-solid fa-paperclip"></i> Attached Documents</h2>
-      <%# TODO: modify logic to show attached documents here! %>
-      <% if true %>
-        <p>This is where documents will be shown</p>
+      <% if @fully_signed_files.any? %>
+        <ul class="document-list">
+          <% @fully_signed_files.each do |file| %>
+            <li>
+              <i class="fa-solid fa-file-lines"></i>
+              <%= link_to file.FileName, "/#{file.FileURLPath}", target: "_blank" %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p>No documents were signed by both parties during this mediation.</p>
       <% end %>
     </div>
   </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,10 @@
         {
           "fingerprint": "ff2ae7632aaf945e870eda7393189bd5ff33943dddeceffb7f691bf1764f8190",
           "note": "Path is sanitized and scoped to public directory. False positive."
+        },
+        {
+          "fingerprint": "7c53b6346e703ef5b1a19fe44a0aec9bd41dbd939f608764e96bc7db4ae884e6",
+          "note": "Path is sanitized and scoped to public directory. False positive."
         }
     ]
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
   get  "/documents/template_preview/:conversation_id", to: "documents#intake_template_view", as: :intake_template_view
   post "/documents/template_generate", to: "documents#generate_filled_template", as: :generate_filled_template
 
+  post "/documents/:id/sign", to: "documents#sign", as: "sign_file"
 
   # Resources
   resources :messages, only: [ :index, :show, :create, :destroy ] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
   get  "/documents/template_preview/:conversation_id", to: "documents#intake_template_view", as: :intake_template_view
   post "/documents/template_generate", to: "documents#generate_filled_template", as: :generate_filled_template
 
-  #post "/documents/:id/sign", to: "documents#sign", as: "sign_file"
+  # post "/documents/:id/sign", to: "documents#sign", as: "sign_file"
   get    "/documents/:id/sign", to: "documents#sign", as: :sign_document
   post   "/documents/:id/apply_signature", to: "documents#apply_signature", as: :apply_signature_document
   # Resources

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,8 +51,9 @@ Rails.application.routes.draw do
   get  "/documents/template_preview/:conversation_id", to: "documents#intake_template_view", as: :intake_template_view
   post "/documents/template_generate", to: "documents#generate_filled_template", as: :generate_filled_template
 
-  post "/documents/:id/sign", to: "documents#sign", as: "sign_file"
-
+  #post "/documents/:id/sign", to: "documents#sign", as: "sign_file"
+  get    "/documents/:id/sign", to: "documents#sign", as: :sign_document
+  post   "/documents/:id/apply_signature", to: "documents#apply_signature", as: :apply_signature_document
   # Resources
   resources :messages, only: [ :index, :show, :create, :destroy ] do
     patch :request_mediator, on: :member

--- a/db/migrate/20250413014657_add_signatures_to_file_drafts.rb
+++ b/db/migrate/20250413014657_add_signatures_to_file_drafts.rb
@@ -1,0 +1,6 @@
+class AddSignaturesToFileDrafts < ActiveRecord::Migration[8.0]
+  def change
+    add_column :FileDrafts, :TenantSignature, :boolean, default: false, null: false
+    add_column :FileDrafts, :LandlordSignature, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20250413205701_add_unique_index_to_side_message_groups.rb
+++ b/db/migrate/20250413205701_add_unique_index_to_side_message_groups.rb
@@ -1,6 +1,5 @@
 class AddUniqueIndexToSideMessageGroups < ActiveRecord::Migration[8.0]
   def change
     add_index :SideMessageGroups, :ConversationID, unique: true, name: "UQ__SideMessageGroups__ConversationID"
-
   end
 end

--- a/db/migrate/20250413205701_add_unique_index_to_side_message_groups.rb
+++ b/db/migrate/20250413205701_add_unique_index_to_side_message_groups.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToSideMessageGroups < ActiveRecord::Migration[8.0]
+  def change
+    add_index :SideMessageGroups, :ConversationID, unique: true, name: "UQ__SideMessageGroups__ConversationID"
+
+  end
+end

--- a/db/migrate/20250413205847_add_tenant_and_landlord_side_conversation_ids_to_primary_message_groups.rb
+++ b/db/migrate/20250413205847_add_tenant_and_landlord_side_conversation_ids_to_primary_message_groups.rb
@@ -1,0 +1,9 @@
+class AddTenantAndLandlordSideConversationIdsToPrimaryMessageGroups < ActiveRecord::Migration[8.0]
+  def change
+    add_column :PrimaryMessageGroups, :TenantSideConversationID, :integer
+    add_column :PrimaryMessageGroups, :LandlordSideConversationID, :integer
+
+    add_foreign_key :PrimaryMessageGroups, :SideMessageGroups, column: :TenantSideConversationID, primary_key: :ConversationID, name: "FK__PrimaryMe__Tenan__Custom"
+    add_foreign_key :PrimaryMessageGroups, :SideMessageGroups, column: :LandlordSideConversationID, primary_key: :ConversationID, name: "FK__PrimaryMe__Landl__Custom"
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,7 +63,8 @@ file_draft = FileDraft.create(
   CreatorID: tenant.UserID,
   FileName: 'test document1',
   FileTypes: 'text/plain',
-  FileURLPath: 'userFiles/TestDocument1.pdf'
+  FileURLPath: 'userFiles/TestDocument1.pdf',
+  TenantSignature: 1
 )
 
 puts "Seed data set 1 created successfully! - 4 users (one of each type) and a sample file (already in the system)"
@@ -120,7 +121,8 @@ file_draft2 = FileDraft.create(
   CreatorID: landlord.UserID,
   FileName: 'test document 2',
   FileTypes: 'text/plain',
-  FileURLPath: 'userFiles/testfile2.txt'
+  FileURLPath: 'userFiles/testfile2.txt',
+  LandlordSignature: 1
 )
 
 puts "Seed data set 2 created successfully! - 4 users (one of each type) and a sample file (already in the system)"


### PR DESCRIPTION
As a note, this will require a db:migrate from all after pulling it.

This PR does the following: 
- Adds the ability to sign documents, both in the negotiation and mediation step, updating both the db (new fields for signatures) and the file itself.
- Adds the functionalities in our summary pages such that they show all the signed documents from both the Primary and Side Message Groups. 
- Adjust the schema in various ways, the biggest of which is to the Side Message Groups, we had/still have our PK for this determined by a composite key, which is just incorrect. I did a bit of a band aid fix to make some of our functionalities possible without a major restructuring. This is the fix: 

    t.index ["ConversationID"], name: "UQ__SideMessageGroups__ConversationID", unique: true
    
- Various bug fixes and updates to seed data, the most important being the chat history bug in the mediation chat boxes (this fix needed the schema change in order to identify the correct sideMessageGroups).  
